### PR TITLE
Feedback TableView is not shown on 64 bit machine

### DIFF
--- a/AAMFeedback/AAMFeedback/AAMFeedbackViewController.m
+++ b/AAMFeedback/AAMFeedback/AAMFeedbackViewController.m
@@ -161,7 +161,7 @@ static BOOL _alwaysUseMainBundle = NO;
     return 4;
 }
 
-- (float)tableView:(UITableView *) tableView heightForRowAtIndexPath:(NSIndexPath *) indexPath {
+- (CGFloat)tableView:(UITableView *) tableView heightForRowAtIndexPath:(NSIndexPath *) indexPath {
     if (indexPath.section == 0 && indexPath.row == 1) {
         return MAX(88, _descriptionTextView.contentSize.height);
     }


### PR DESCRIPTION
Feedback TableView is not shown on 64 bit machine. It is happened on iPhone5s and 64 bit simulator.

`UITableViewDataSource` defined `(CGFloat)tableView:(UITableView *) tableView heightForRowAtIndexPath:(NSIndexPath *) indexPath`. Currently `AAMFeedbackViewController` returns `float`. CGFloat is implemented with `float` on 32 bit, but it is double on 64 bit. Type miss match between interface and implementation isn't casted. Therefore, TableViewCell height become 0 on 64 bit machine.
