### PR TITLE
frameworkに対応

### DIFF
--- a/AAMFeedback/AAMFeedback/AAMFeedbackViewController.h
+++ b/AAMFeedback/AAMFeedback/AAMFeedbackViewController.h
@@ -19,7 +19,6 @@
 @property(strong, nonatomic) NSArray *toRecipients;
 @property(strong, nonatomic) NSArray *ccRecipients;
 @property(strong, nonatomic) NSArray *bccRecipients;
-@property(strong, nonatomic) NSBundle *applicationBundle;
 #pragma mark - customize
 @property(strong, nonatomic) UIImage *backgroundImage;
 @property(nonatomic) NSInteger selectedTopicsIndex;

--- a/AAMFeedback/AAMFeedback/AAMFeedbackViewController.h
+++ b/AAMFeedback/AAMFeedback/AAMFeedbackViewController.h
@@ -19,6 +19,7 @@
 @property(strong, nonatomic) NSArray *toRecipients;
 @property(strong, nonatomic) NSArray *ccRecipients;
 @property(strong, nonatomic) NSArray *bccRecipients;
+@property(strong, nonatomic) NSBundle *applicationBundle;
 #pragma mark - customize
 @property(strong, nonatomic) UIImage *backgroundImage;
 @property(nonatomic) NSInteger selectedTopicsIndex;

--- a/AAMFeedback/AAMFeedback/AAMFeedbackViewController.m
+++ b/AAMFeedback/AAMFeedback/AAMFeedbackViewController.m
@@ -71,7 +71,7 @@ static BOOL _alwaysUseMainBundle = NO;
     if (_alwaysUseMainBundle) {
         bundle = [NSBundle mainBundle];
     } else {
-        NSURL *bundleURL = [[NSBundle mainBundle] URLForResource:@"AAMFeedback" withExtension:@"bundle"];
+        NSURL *bundleURL = [[NSBundle bundleForClass:self.class] URLForResource:@"AAMFeedback" withExtension:@"bundle"];
         if (bundleURL) {
             // AAMFeedback.bundle will likely only exist when used via CocoaPods
             bundle = [NSBundle bundleWithURL:bundleURL];

--- a/AAMFeedback/AAMFeedback/AAMFeedbackViewController.m
+++ b/AAMFeedback/AAMFeedback/AAMFeedbackViewController.m
@@ -83,12 +83,6 @@ static BOOL _alwaysUseMainBundle = NO;
     return bundle;
 }
 
-- (NSBundle *)applicationBundle {
-    if (!_applicationBundle) {
-        _applicationBundle = [NSBundle mainBundle];
-    }
-    return _applicationBundle;
-}
 
 #pragma mark - View lifecycle
 
@@ -424,11 +418,11 @@ static BOOL _alwaysUseMainBundle = NO;
 }
 
 - (NSString *)_appName {
-    return [self.applicationBundle infoDictionary][@"CFBundleDisplayName"];
+    return [[NSBundle mainBundle] infoDictionary][@"CFBundleDisplayName"];
 }
 
 - (NSString *)_appVersion {
-    return [self.applicationBundle infoDictionary][@"CFBundleVersion"];
+    return [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
 }
 
 

--- a/AAMFeedback/AAMFeedback/AAMFeedbackViewController.m
+++ b/AAMFeedback/AAMFeedback/AAMFeedbackViewController.m
@@ -83,6 +83,12 @@ static BOOL _alwaysUseMainBundle = NO;
     return bundle;
 }
 
+- (NSBundle *)applicationBundle {
+    if (!_applicationBundle) {
+        _applicationBundle = [NSBundle mainBundle];
+    }
+    return _applicationBundle;
+}
 
 #pragma mark - View lifecycle
 
@@ -418,11 +424,11 @@ static BOOL _alwaysUseMainBundle = NO;
 }
 
 - (NSString *)_appName {
-    return [[NSBundle mainBundle] infoDictionary][@"CFBundleDisplayName"];
+    return [self.applicationBundle infoDictionary][@"CFBundleDisplayName"];
 }
 
 - (NSString *)_appVersion {
-    return [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
+    return [self.applicationBundle infoDictionary][@"CFBundleVersion"];
 }
 
 


### PR DESCRIPTION
CocoaPods 0.36移行でframeworkを使っていると`mainBundle`がframeworkのものになるため，ローカライズ情報やアプリケーション情報が取得できません．
ローカライズについては自分のバンドルを，アプリケーション情報についてはバンドルをインジェクションできるように変更しました．
