### PR TITLE
特定のユースケース以外では不適切なattentionメッセージを削除する

### DIFF
--- a/AAMFeedback/AAMFeedback/AAMFeedbackViewController.m
+++ b/AAMFeedback/AAMFeedback/AAMFeedbackViewController.m
@@ -206,7 +206,7 @@ static BOOL _alwaysUseMainBundle = NO;
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
     switch (section) {
         case 0:
-            return self.tableHeaderAttention;
+            return self.attention.length > 0 ? self.tableHeaderAttention : nil;
         case 1:
             return self.tableHeaderTopics;
         case 2:

--- a/AAMFeedback/AAMFeedback/AAMFeedbackViewController.m
+++ b/AAMFeedback/AAMFeedback/AAMFeedbackViewController.m
@@ -90,7 +90,6 @@ static BOOL _alwaysUseMainBundle = NO;
     ];
     self.topicsToSend = [self.topics copy];
     self.descriptionPlaceHolder = NSLocalizedStringFromTableInBundle(@"AAMFeedbackDescriptionPlaceholder", @"AAMLocalizable", [AAMFeedbackViewController bundle], nil);
-    self.attention = NSLocalizedStringFromTableInBundle(@"AAMFeedbackAttention", @"AAMLocalizable", [AAMFeedbackViewController bundle], nil);
     self.topicsTitle = NSLocalizedStringFromTableInBundle(@"AAMFeedbackTopicsTitle", @"AAMLocalizable", [AAMFeedbackViewController bundle], nil);
     self.tableHeaderAttention = NSLocalizedStringFromTableInBundle(@"AAMFeedbackTableHeaderAttention", @"AAMLocalizable", [AAMFeedbackViewController bundle], nil);
     self.tableHeaderBasicInfo = NSLocalizedStringFromTableInBundle(@"AAMFeedbackTableHeaderBasicInfo", @"AAMLocalizable", [AAMFeedbackViewController bundle], nil);

--- a/AAMFeedback/AAMFeedback/en.lproj/AAMLocalizable.strings
+++ b/AAMFeedback/AAMFeedback/en.lproj/AAMLocalizable.strings
@@ -17,9 +17,6 @@
 "AAMFeedbackTableHeaderTopics" = "Please Fill";
 "AAMFeedbackTableHeaderBasicInfo" = "Your Environment";
 
-// Attention
-"AAMFeedbackAttention" = "Please confirm the setting so that you can receive @karadanote.jp.";
-
 // Topics Options
 "AAMFeedbackTopicsQuestion" = "Question";
 "AAMFeedbackTopicsRequest" = "Request";

--- a/AAMFeedback/AAMFeedback/es.lproj/AAMLocalizable.strings
+++ b/AAMFeedback/AAMFeedback/es.lproj/AAMLocalizable.strings
@@ -15,9 +15,6 @@
 "AAMFeedbackTableHeaderTopics" = "Por favor, complete";
 "AAMFeedbackTableHeaderBasicInfo" = "Tu Entorno";
 
-// Attention
-"AAMFeedbackAttention" = "Gracias a comprobar la configuración para permitir la recepción de @karadanote.jp.";
-
 // Topics Options
 "AAMFeedbackTopicsQuestion" = "Pregunta";
 "AAMFeedbackTopicsRequest" = "Solicitud";

--- a/AAMFeedback/AAMFeedback/ja.lproj/AAMLocalizable.strings
+++ b/AAMFeedback/AAMFeedback/ja.lproj/AAMLocalizable.strings
@@ -17,9 +17,6 @@
 "AAMFeedbackTableHeaderTopics" = "入力事項";
 "AAMFeedbackTableHeaderBasicInfo" = "動作環境の情報";
 
-// Attention
-"AAMFeedbackAttention" = "メールの受信設定により返信メールが届かない場合がございます。\n@karadanote.jp の受信ができるように設定の確認をお願いいたします。";
-
 // Topics Options
 "AAMFeedbackTopicsQuestion" = "質問";
 "AAMFeedbackTopicsRequest" = "リクエスト";


### PR DESCRIPTION
CocoaPodsでpod updateしたところ、karadanote.jpからのメールの受信を許可するような注意書きが表示されるようになりました。

恐らくは特定のユースケースのために行った変更だと思いますが、その他のユースケースでは不適切な内容であると思います。したがってデフォルト値として設定するべきではないと思います。

# Ref.

- https://github.com/PlusR/AAMFeedback/pull/16
- https://github.com/PlusR/AAMFeedback/pull/18