### PR TITLE
Use System Colors and Semantic Colors for Dark Mode

### DIFF
--- a/AAMFeedback/AAMFeedback/AAMFeedbackTopicsViewController.m
+++ b/AAMFeedback/AAMFeedback/AAMFeedbackTopicsViewController.m
@@ -86,7 +86,11 @@
     NSUInteger n = [cells count];
     for (int i = 0; i < n; i++) {
         UITableViewCell *cell = cells[(NSUInteger)i];
-        cell.textLabel.textColor = [UIColor blackColor];
+        if (@available(iOS 13.0, *)) {
+            cell.textLabel.textColor = [UIColor labelColor];
+        } else {
+            cell.textLabel.textColor = [UIColor blackColor];
+        }
         cell.accessoryType = UITableViewCellAccessoryNone;
     }
 
@@ -95,7 +99,7 @@
     UITableViewCell *cell;
     cell = [self.tableView cellForRowAtIndexPath:path];
     cell.accessoryType = UITableViewCellAccessoryCheckmark;
-    cell.textLabel.textColor = [UIColor colorWithRed:51.0f / 255.0f green:102.0f / 255.0f blue:153.0f / 255.0f alpha:1.0f];
+    cell.textLabel.textColor = [UIColor systemBlueColor];
     [cell setSelected:NO animated:YES];
 }
 

--- a/AAMFeedback/AAMFeedback/AAMFeedbackViewController.m
+++ b/AAMFeedback/AAMFeedback/AAMFeedbackViewController.m
@@ -253,7 +253,7 @@ static BOOL _alwaysUseMainBundle = NO;
                 self.descriptionPlaceHolderLabel.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleRightMargin;
                 self.descriptionPlaceHolderLabel.font = [UIFont systemFontOfSize:16];
                 self.descriptionPlaceHolderLabel.text = self.descriptionPlaceHolder;
-                self.descriptionPlaceHolderLabel.textColor = [UIColor lightGrayColor];
+                self.descriptionPlaceHolderLabel.textColor = [UIColor systemGrayColor];
                 self.descriptionPlaceHolderLabel.numberOfLines = 0;
                 self.descriptionPlaceHolderLabel.userInteractionEnabled = NO;
                 [cell.contentView addSubview:self.descriptionPlaceHolderLabel];
@@ -268,7 +268,7 @@ static BOOL _alwaysUseMainBundle = NO;
     switch (indexPath.section) {
         case 0:
             cell.textLabel.text = self.attention;
-            cell.textLabel.textColor = [UIColor redColor];
+            cell.textLabel.textColor = [UIColor systemRedColor];
             cell.textLabel.font = [UIFont systemFontOfSize:14];
             cell.selectionStyle = UITableViewCellSelectionStyleNone;
             break;


### PR DESCRIPTION
In iOS 13/Dark Mode, it is difficult to see hardcoded colors.
So, library use System Colors and Semantic Colors for the first step of Supporting Dark Mode.